### PR TITLE
# Added nil handling for generated methods

### DIFF
--- a/examples/zap-marshaler-secure/example_test.go
+++ b/examples/zap-marshaler-secure/example_test.go
@@ -318,9 +318,18 @@ func ExampleNotLoggingWellKnownTypeMessage() {
 func ExampleMixedLoggingMessage() {
 	l := zap.NewExample()
 	l.Info("test", zap.Object("mlm", &MixedLoggingMessage{
-		StringValue:          "xxx",
-		BoolValue:            true,
-		Int32Value:           1,
+		StringValue: "xxx",
+		BoolValue:   true,
+		Int32Value:  1,
 	}))
 	// output: {"level":"info","msg":"test","mlm":{"string_value":"xxx"}}
+}
+
+func ExampleTestWithNilField() {
+	l := zap.NewExample()
+	sl := l.Sugar()
+	var sm *SimpleMessage = nil
+	sl = sl.With("SimpleMessage", sm)
+	sl.Infow("test")
+	// output: {"level":"info","msg":"test","SimpleMessage":{}}
 }

--- a/examples/zap-marshaler/example_test.go
+++ b/examples/zap-marshaler/example_test.go
@@ -324,3 +324,12 @@ func ExampleMixedLoggingMessage() {
 	}))
 	// {"level":"info","msg":"test","mlm":{"string_value":"xxx","bool_value":true,"int32_value":1}}
 }
+
+func ExampleTestWithNilField() {
+	l := zap.NewExample()
+	sl := l.Sugar()
+	var sm *SimpleMessage = nil
+	sl = sl.With("SimpleMessage", sm)
+	sl.Infow("test")
+	// output: {"level":"info","msg":"test","SimpleMessage":{}}
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
-	"github.com/kazegusuri/go-proto-zap-marshaler"
+	zap_marshaler "github.com/kazegusuri/go-proto-zap-marshaler"
 )
 
 type plugin struct {
@@ -74,7 +74,7 @@ func (p *plugin) generateProto3Message(file *generator.FileDescriptor, message *
 	p.P("if m == nil {")
 	p.P("return nil")
 	p.P("}")
-	p.P(""
+	p.P("")
 
 	for _, field := range message.Field {
 		// see the field option only when secure option is true.

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -71,6 +71,10 @@ func (p *plugin) generateProto3Message(file *generator.FileDescriptor, message *
 	p.P("var keyName string")
 	p.P("_ = keyName")
 	p.P("")
+	p.P("if m == nil {")
+	p.P("return nil")
+	p.P("}")
+	p.P(""
 
 	for _, field := range message.Field {
 		// see the field option only when secure option is true.


### PR DESCRIPTION
SugaredLoggers panic when calling MarshalLogObject() method with a nil argument.
This adds a nil check before marshalling individual fields to avoid this potenial panic